### PR TITLE
Fix recursive file discovery for build step

### DIFF
--- a/lib/tasks/run.js
+++ b/lib/tasks/run.js
@@ -70,10 +70,11 @@ class RunTask {
         opt.buildargs = util.parseArgs(this.build.args);
       }
 
-      const files = await util.getFiles(context, filter);
+      const fileFilter = filter || (() => true);
+      const files = await util.getFiles(context, fileFilter);
       const src = files
         .map(relative.bind(null, context))
-        .filter(filter);
+        .filter(fileFilter);
       const stream = await this.docker.buildImage({
         context,
         src

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,5 +1,5 @@
 import yaml from 'js-yaml';
-import { resolve } from 'path';
+import { resolve, relative } from 'path';
 import { split } from 'shlex';
 import { parseRepositoryTag as _parseRepositoryTag } from 'dockerode/lib/util.js';
 import { promises as fs } from 'fs';
@@ -54,19 +54,22 @@ export function buildOutputBufferStream() {
   return res;
 }
 
-export async function getFiles(dir) {
+export async function getFiles(dir, filter = () => true, root = dir) {
   const files = [];
-  const dirReads = [];
   const dirents = await fs.readdir(dir, { withFileTypes: true });
+
   for (const dirent of dirents) {
     const file = resolve(dir, dirent.name);
     if (dirent.isDirectory()) {
-      dirReads.push(getFiles(file));
+      files.push(...await getFiles(file, filter, root));
     } else {
-      files.push(file);
+      const rel = relative(root, file);
+      if (filter(rel)) {
+        files.push(file);
+      }
     }
   }
-  files.concat(...await Promise.all(dirReads));
+
   return files;
 }
 


### PR DESCRIPTION
## Summary
- fix `getFiles` recursion and add optional filter
- guard build step when no `.dockerignore` is present

## Testing
- `npm run lint`
- `npm test` *(fails: connect ENOENT /var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_687d66d3981883278a40834ef70f08b9